### PR TITLE
set the original root window back to key and visible

### DIFF
--- a/DBAlertController/Pod/DBAlertController.swift
+++ b/DBAlertController/Pod/DBAlertController.swift
@@ -40,6 +40,9 @@ public class DBAlertController: UIAlertController {
     */
     public func dismiss(animated flag: Bool = true, completion: (() -> Void)? = nil) {
         dismissViewControllerAnimated(flag, completion: completion)
+        if let app = UIApplication.sharedApplication().delegate as? AppDelegate, let window = app.window {
+            window.makeKeyAndVisible()
+        }
     }
     
     


### PR DESCRIPTION
DBAlertController can be used with more than just UIAlertController, but for this to work properly it requires setting the root window back to key and visible on dismiss. I'm using this code but please test thoroughly.
