### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Adding UIAlertView's show() functionality to UIAlertController.
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/DBAlertController.svg)](https://img.shields.io/cocoapods/v/DBAlertController.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/DBAlertController.svg)](https://img.shields.io/cocoapods/v/DBAlertController.svg)
 
 ## Background
 Have you ever needed to present an alert without knowing the visible view controller? In case you're drawing a blank, let me give an example.
@@ -52,7 +52,7 @@ DBAlertController fixes the issue above by presenting the UIAlertController on i
 
 ## Installation
 
-### Cocoapods
+### CocoaPods
 Add `pod 'DBAlertController'` to your Podfile.
 
 ### Carthage


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
