### PR TITLE
Renaming of UIWindow.window.alert

### DIFF
--- a/Source/DBAlertController.swift
+++ b/Source/DBAlertController.swift
@@ -15,7 +15,7 @@ open class DBAlertController: UIAlertController {
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = DBClearViewController()
         window.backgroundColor = UIColor.clear
-		window.windowLevel = UIWindowLevelAlert
+		window.windowLevel = UIWindow.Level.alert
         return window
     }()
     


### PR DESCRIPTION
This change is necessary with the latests Xcode and Swift Versions, please accept it on the upstream repo and also perhaps merge it back to the master branch. 